### PR TITLE
Update docker repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ active = true
 
 We store prebuilt Docker images for each instance. They can be found in this directory:
 
-https://hub.docker.com/repository/docker/jefzda/sweap-images/general
+https://hub.docker.com/r/jefzda/sweap-images
 
 The format of the images is as follows.
 


### PR DESCRIPTION
Hi team, excellent work and thank you for sharing with the community!

This PR is to make a small link update since `https://hub.docker.com/repository/docker/jefzda/sweap-images/general` is not publicly available. 

