### PR TITLE
Fix Commercial Leaderboard link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Code and data for the following works:
 
 * Public Leaderboard: <a href="https://scale.com/leaderboard/swe_bench_pro_public">https://scale.com/leaderboard/swe_bench_pro_public</a>
 
-* Commercial (Private) Leaderboard: <a href="https://labs.scale.com/leaderboard/swe_bench_pro_private">https://scale.com/leaderboard/swe_bench_pro_commercial</a>
+* Commercial (Private) Leaderboard: <a href="https://labs.scale.com/leaderboard/swe_bench_pro_private">https://labs.scale.com/leaderboard/swe_bench_pro_private</a>
 
 ## News
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Code and data for the following works:
 
 * Public Leaderboard: <a href="https://scale.com/leaderboard/swe_bench_pro_public">https://scale.com/leaderboard/swe_bench_pro_public</a>
 
-* Commercial (Private) Leaderboard: <a href="https://scale.com/leaderboard/swe_bench_pro_commercial">https://scale.com/leaderboard/swe_bench_pro_commercial</a>
+* Commercial (Private) Leaderboard: <a href="https://labs.scale.com/leaderboard/swe_bench_pro_private">https://scale.com/leaderboard/swe_bench_pro_commercial</a>
 
 ## News
 


### PR DESCRIPTION
Updated the link for the Commercial (Private) Leaderboard.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the Commercial (Private) Leaderboard URL in the README from `https://scale.com/leaderboard/swe_bench_pro_commercial` to `https://labs.scale.com/leaderboard/swe_bench_pro_private`. Both the `href` attribute and the display text are updated consistently.

- Single-line change updating a broken/outdated leaderboard link
- No code logic, dependencies, or configuration affected

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it's a single-line documentation link fix with no code changes.

The change is a trivial URL update in the README. Both the href and display text are updated consistently. No code, configuration, or logic is affected.

No files require special attention.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Updates the Commercial (Private) Leaderboard link to the new URL. Both href and display text are consistent. No issues found. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README.md"] --> B["Commercial Leaderboard Link"]
    B --> C["Old: scale.com/leaderboard/swe_bench_pro_commercial"]
    B --> D["New: labs.scale.com/leaderboard/swe_bench_pro_private"]
    style C fill:#f88,stroke:#a00
    style D fill:#8f8,stroke:#0a0
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update README.md"](https://github.com/scaleapi/swe-bench_pro-os/commit/ef70a05ac2e64941d0cdfc12fc91905b4d144944) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26603484)</sub>

<!-- /greptile_comment -->