### PR TITLE
Add detailed, human readable, eval_results schema (status, F2P/P2P breakdown)

### DIFF
--- a/swe_bench_pro_eval.py
+++ b/swe_bench_pro_eval.py
@@ -276,6 +276,60 @@ def collect_outputs_local(workspace_dir, output_dir, uid, prefix):
         return None
 
 
+# ── Detailed eval_results helpers ───────────────────────────────────────────────
+#
+# Each per-instance entry in eval_results.json is a dict with the following keys
+# (rather than a plain bool):
+#
+#   {
+#     "status":        "Pass" | "Fail",
+#     "resolved":      bool,                 # convenience flag = (status == "Pass")
+#     "PASS_TO_PASS":  "N/M passed (failed: a, b, c)",   # human-readable summary
+#     "FAIL_TO_PASS":  "N/M passed (failed: a, b, c)",
+#     "error":         "<message>"           # only present on failure paths
+#   }
+#
+# This makes it possible to triage failures (test-failure vs. setup-failure vs.
+# exception) without opening the per-instance log files.
+
+def _make_failure_result(error_msg: str) -> dict:
+    return {
+        "status": "Fail",
+        "resolved": False,
+        "PASS_TO_PASS": "",
+        "FAIL_TO_PASS": "",
+        "error": error_msg,
+    }
+
+
+def _format_test_breakdown(expected: set, passed: set) -> str:
+    actually_passed = expected & passed
+    failed = expected - passed
+    line = f"{len(actually_passed)}/{len(expected)} passed"
+    if failed:
+        line += f" (failed: {', '.join(sorted(failed))})"
+    return line
+
+
+def _build_detailed_result(f2p: set, p2p: set, passed_tests: set) -> dict:
+    resolved = (f2p | p2p) <= passed_tests
+    return {
+        "status": "Pass" if resolved else "Fail",
+        "resolved": resolved,
+        "PASS_TO_PASS": _format_test_breakdown(p2p, passed_tests),
+        "FAIL_TO_PASS": _format_test_breakdown(f2p, passed_tests),
+    }
+
+
+def _running_accuracy(eval_results: dict) -> float:
+    if not eval_results:
+        return 0.0
+    resolved = sum(
+        1 for r in eval_results.values() if isinstance(r, dict) and r.get("resolved")
+    )
+    return resolved / len(eval_results)
+
+
 def eval_with_modal(patch, sample, output_dir, dockerhub_username, scripts_dir, prefix="", redo=False, block_network=False, docker_platform=None):
     if modal is None:
         raise RuntimeError("modal is not installed. Install it or run with --use_local_docker")
@@ -544,31 +598,35 @@ def main():
                 output = future.result()
                 if output is None:
                     print(f'Evaluation for {patch_sample["instance_id"]} returned None')
-                    eval_results[patch_sample["instance_id"]] = False
+                    eval_results[patch_sample["instance_id"]] = _make_failure_result(
+                        "Evaluation returned None"
+                    )
                 else:
                     instance_id = patch_sample["instance_id"]
                     if instance_id not in raw_sample_df.index:
                         print(f'Warning: Instance {instance_id} not found in raw sample data, skipping')
-                        eval_results[instance_id] = False
+                        eval_results[instance_id] = _make_failure_result(
+                            "Instance not found in raw sample data"
+                        )
                     else:
                         raw_sample = raw_sample_df.loc[instance_id]
-                        passed_tests = {x["name"] for x in output["tests"] if x["status"] == "PASSED"}
+                        passed_tests = {x["name"] for x in output.get("tests", []) if x["status"] == "PASSED"}
                         f2p = set(eval(raw_sample["fail_to_pass"]))
                         p2p = set(eval(raw_sample["pass_to_pass"]))
-                        result = (f2p | p2p) <= passed_tests
-                        eval_results[instance_id] = result
+                        eval_results[instance_id] = _build_detailed_result(
+                            f2p, p2p, passed_tests
+                        )
 
-                current_accuracy = sum(eval_results.values()) / len(eval_results)
+                current_accuracy = _running_accuracy(eval_results)
                 pbar.set_description(f"Accuracy: {current_accuracy:.2%}")
             except Exception as exc:
                 print(f'Evaluation for {patch_sample["instance_id"]} generated an exception: {exc}')
-                eval_results[patch_sample["instance_id"]] = False
-                # Update progress bar description with current accuracy
-                current_accuracy = sum(eval_results.values()) / len(eval_results)
+                eval_results[patch_sample["instance_id"]] = _make_failure_result(str(exc))
+                current_accuracy = _running_accuracy(eval_results)
                 pbar.set_description(f"Accuracy: {current_accuracy:.2%}")
     with open(os.path.join(args.output_dir, "eval_results.json"), "w") as f:
-        json.dump(eval_results, f)
-    print("Overall accuracy: ", sum(eval_results.values()) / len(eval_results))
+        json.dump(eval_results, f, indent=2)
+    print("Overall accuracy: ", _running_accuracy(eval_results))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace the per-instance bool in eval_results.json with a structured dict that exposes which specific FAIL_TO_PASS / PASS_TO_PASS tests passed or failed, plus an error message on failure paths. This lets users triage failures without opening per-instance log files.

Schema change
- Before: {instance_id: True/False}
- After:  {instance_id: {
            "status":       "Pass" | "Fail",
            "resolved":     bool,    # convenience flag
            "PASS_TO_PASS": "N/M passed (failed: t1, t2, ...)",
            "FAIL_TO_PASS": "N/M passed (failed: t1, t2, ...)",
            "error":        "..."    # only on failure paths
         }}

This is a breaking change for any downstream consumer that parses eval_results.json as {id: bool}. The "resolved" key is provided as a convenience flag so most migrations are mechanical:

    # Before
    if eval_results[id]: ...
    sum(eval_results.values())

    # After
    if eval_results[id]["resolved"]: ...
    sum(r["resolved"] for r in eval_results.values())

Also pretty-prints eval_results.json with indent=2 since the new structure benefits from human-readable formatting.

Internal cleanup
- Extracted _make_failure_result, _format_test_breakdown, _build_detailed_result, and _running_accuracy helpers so the main loop reads at one level of abstraction.
- Uses output.get("tests", []) to avoid KeyError on partially-populated outputs.

No new dependencies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the flat `{instance_id: bool}` format in `eval_results.json` with a richer `{instance_id: {status, resolved, PASS_TO_PASS, FAIL_TO_PASS, error}}` schema, extracting four focused helper functions to keep the main loop readable and adding `indent=2` pretty-printing.

- **Schema change**: each entry now carries a human-readable breakdown of which tests passed/failed and an `error` field on infra-failure paths, making triage possible without consulting per-instance logs.
- **Helpers**: `_make_failure_result`, `_format_test_breakdown`, `_build_detailed_result`, and `_running_accuracy` are all well-scoped; `output.get(\"tests\", [])` defensively handles partially-populated outputs.
- **Breaking change**: downstream consumers reading `eval_results[id]` as a bool must migrate to `eval_results[id][\"resolved\"]`; a migration guide is included in the PR description.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the core logic is correct and this is additive schema enrichment; the main risk is downstream consumers parsing the human-readable breakdown strings, which have a subtle format inconsistency between infra-failure and test-failure entries.

The result-building logic is sound and `_running_accuracy` faithfully replicates the old denominator semantics. Two format inconsistencies exist: `_make_failure_result` stores `""` for `PASS_TO_PASS`/`FAIL_TO_PASS` while `_build_detailed_result` always stores a formatted `"N/M passed ..."` string, and `_format_test_breakdown` emits the ambiguous `"0/0 passed"` for instances with no tests of a given type. Neither causes a runtime failure in the writer, but both can surprise consumers who parse these strings.

swe_bench_pro_eval.py — specifically `_make_failure_result` and `_format_test_breakdown` and their interaction with the documented schema.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| swe_bench_pro_eval.py | Adds structured per-instance result dicts to eval_results.json, replacing plain booleans; logic is correct but PASS_TO_PASS/FAIL_TO_PASS field format is inconsistent between infra-failure and test-failure paths. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[future.result] -->|is None| B[_make_failure_result]
    A -->|output dict| C{instance_id in raw_sample_df?}
    C -->|No| D[_make_failure_result]
    C -->|Yes| E[collect passed_tests via output.get tests]
    E --> F[eval f2p and p2p from raw_sample]
    F --> G[_build_detailed_result]
    G --> H{f2p union p2p subset of passed_tests?}
    H -->|Yes| I[status: Pass, resolved: True]
    H -->|No| J[status: Fail, resolved: False]
    A -->|raises Exception| K[_make_failure_result with str of exc]
    B --> L[result with error key, PASS_TO_PASS empty string]
    D --> L
    K --> L
    I --> M[result without error key, formatted PASS_TO_PASS and FAIL_TO_PASS]
    J --> M
    L --> N[eval_results dict]
    M --> N
    N --> O[_running_accuracy]
    N --> P[json.dump with indent=2]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aswe_bench_pro_eval.py%3A295-302%0AInconsistent%20%60PASS_TO_PASS%60%2F%60FAIL_TO_PASS%60%20value%20format%20between%20the%20two%20result%20constructors.%20%60_make_failure_result%60%20stores%20empty%20strings%20%60%22%22%60%20for%20these%20fields%2C%20while%20%60_build_detailed_result%60%20always%20stores%20a%20formatted%20%60%22N%2FM%20passed%20%28failed%3A%20...%29%22%60%20string.%20The%20module-level%20schema%20comment%20documents%20both%20fields%20as%20%60%22N%2FM%20passed%20%28failed%3A%20a%2C%20b%2C%20c%29%22%60%20without%20noting%20the%20empty-string%20exception%2C%20so%20any%20consumer%20that%20tries%20to%20parse%20the%20count%20%28%60result%5B%22FAIL_TO_PASS%22%5D.split%28%22%2F%22%29%5B0%5D%60%2C%20etc.%29%20will%20crash%20on%20infra-failure%20entries.%20Setting%20these%20to%20%60%22N%2FA%22%60%20for%20infra%20failures%20would%20make%20the%20format%20uniform%20and%20safe%20to%20parse.%0A%0A%60%60%60suggestion%0Adef%20_make_failure_result%28error_msg%3A%20str%29%20-%3E%20dict%3A%0A%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%22status%22%3A%20%22Fail%22%2C%0A%20%20%20%20%20%20%20%20%22resolved%22%3A%20False%2C%0A%20%20%20%20%20%20%20%20%22PASS_TO_PASS%22%3A%20%22N%2FA%22%2C%0A%20%20%20%20%20%20%20%20%22FAIL_TO_PASS%22%3A%20%22N%2FA%22%2C%0A%20%20%20%20%20%20%20%20%22error%22%3A%20error_msg%2C%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aswe_bench_pro_eval.py%3A305-311%0A%60_format_test_breakdown%60%20returns%20%60%220%2F0%20passed%22%60%20when%20%60expected%60%20is%20an%20empty%20set%20%28i.e.%2C%20the%20instance%20has%20no%20FAIL_TO_PASS%20or%20no%20PASS_TO_PASS%20tests%29.%20This%20is%20ambiguous%20%E2%80%94%20it%20looks%20identical%20to%20a%20case%20where%20all%20zero-of-zero%20tests%20ran%20and%20passed.%20A%20special%20case%20would%20make%20it%20unambiguous%20to%20readers%20and%20downstream%20parsers.%0A%0A%60%60%60suggestion%0Adef%20_format_test_breakdown%28expected%3A%20set%2C%20passed%3A%20set%29%20-%3E%20str%3A%0A%20%20%20%20if%20not%20expected%3A%0A%20%20%20%20%20%20%20%20return%20%22N%2FA%20%28no%20tests%29%22%0A%20%20%20%20actually_passed%20%3D%20expected%20%26%20passed%0A%20%20%20%20failed%20%3D%20expected%20-%20passed%0A%20%20%20%20line%20%3D%20f%22%7Blen%28actually_passed%29%7D%2F%7Blen%28expected%29%7D%20passed%22%0A%20%20%20%20if%20failed%3A%0A%20%20%20%20%20%20%20%20line%20%2B%3D%20f%22%20%28failed%3A%20%7B'%2C%20'.join%28sorted%28failed%29%29%7D%29%22%0A%20%20%20%20return%20line%0A%60%60%60%0A%0A&pr=104&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aswe_bench_pro_eval.py%3A295-302%0AInconsistent%20%60PASS_TO_PASS%60%2F%60FAIL_TO_PASS%60%20value%20format%20between%20the%20two%20result%20constructors.%20%60_make_failure_result%60%20stores%20empty%20strings%20%60%22%22%60%20for%20these%20fields%2C%20while%20%60_build_detailed_result%60%20always%20stores%20a%20formatted%20%60%22N%2FM%20passed%20%28failed%3A%20...%29%22%60%20string.%20The%20module-level%20schema%20comment%20documents%20both%20fields%20as%20%60%22N%2FM%20passed%20%28failed%3A%20a%2C%20b%2C%20c%29%22%60%20without%20noting%20the%20empty-string%20exception%2C%20so%20any%20consumer%20that%20tries%20to%20parse%20the%20count%20%28%60result%5B%22FAIL_TO_PASS%22%5D.split%28%22%2F%22%29%5B0%5D%60%2C%20etc.%29%20will%20crash%20on%20infra-failure%20entries.%20Setting%20these%20to%20%60%22N%2FA%22%60%20for%20infra%20failures%20would%20make%20the%20format%20uniform%20and%20safe%20to%20parse.%0A%0A%60%60%60suggestion%0Adef%20_make_failure_result%28error_msg%3A%20str%29%20-%3E%20dict%3A%0A%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%22status%22%3A%20%22Fail%22%2C%0A%20%20%20%20%20%20%20%20%22resolved%22%3A%20False%2C%0A%20%20%20%20%20%20%20%20%22PASS_TO_PASS%22%3A%20%22N%2FA%22%2C%0A%20%20%20%20%20%20%20%20%22FAIL_TO_PASS%22%3A%20%22N%2FA%22%2C%0A%20%20%20%20%20%20%20%20%22error%22%3A%20error_msg%2C%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aswe_bench_pro_eval.py%3A305-311%0A%60_format_test_breakdown%60%20returns%20%60%220%2F0%20passed%22%60%20when%20%60expected%60%20is%20an%20empty%20set%20%28i.e.%2C%20the%20instance%20has%20no%20FAIL_TO_PASS%20or%20no%20PASS_TO_PASS%20tests%29.%20This%20is%20ambiguous%20%E2%80%94%20it%20looks%20identical%20to%20a%20case%20where%20all%20zero-of-zero%20tests%20ran%20and%20passed.%20A%20special%20case%20would%20make%20it%20unambiguous%20to%20readers%20and%20downstream%20parsers.%0A%0A%60%60%60suggestion%0Adef%20_format_test_breakdown%28expected%3A%20set%2C%20passed%3A%20set%29%20-%3E%20str%3A%0A%20%20%20%20if%20not%20expected%3A%0A%20%20%20%20%20%20%20%20return%20%22N%2FA%20%28no%20tests%29%22%0A%20%20%20%20actually_passed%20%3D%20expected%20%26%20passed%0A%20%20%20%20failed%20%3D%20expected%20-%20passed%0A%20%20%20%20line%20%3D%20f%22%7Blen%28actually_passed%29%7D%2F%7Blen%28expected%29%7D%20passed%22%0A%20%20%20%20if%20failed%3A%0A%20%20%20%20%20%20%20%20line%20%2B%3D%20f%22%20%28failed%3A%20%7B'%2C%20'.join%28sorted%28failed%29%29%7D%29%22%0A%20%20%20%20return%20line%0A%60%60%60%0A%0A&repo=scaleapi%2Fswe-bench_pro-os&pr=104&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fswe-bench_pro-os%22%20on%20the%20existing%20branch%20%22upstream-contrib%2Fdetailed-eval-results%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22upstream-contrib%2Fdetailed-eval-results%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aswe_bench_pro_eval.py%3A295-302%0AInconsistent%20%60PASS_TO_PASS%60%2F%60FAIL_TO_PASS%60%20value%20format%20between%20the%20two%20result%20constructors.%20%60_make_failure_result%60%20stores%20empty%20strings%20%60%22%22%60%20for%20these%20fields%2C%20while%20%60_build_detailed_result%60%20always%20stores%20a%20formatted%20%60%22N%2FM%20passed%20%28failed%3A%20...%29%22%60%20string.%20The%20module-level%20schema%20comment%20documents%20both%20fields%20as%20%60%22N%2FM%20passed%20%28failed%3A%20a%2C%20b%2C%20c%29%22%60%20without%20noting%20the%20empty-string%20exception%2C%20so%20any%20consumer%20that%20tries%20to%20parse%20the%20count%20%28%60result%5B%22FAIL_TO_PASS%22%5D.split%28%22%2F%22%29%5B0%5D%60%2C%20etc.%29%20will%20crash%20on%20infra-failure%20entries.%20Setting%20these%20to%20%60%22N%2FA%22%60%20for%20infra%20failures%20would%20make%20the%20format%20uniform%20and%20safe%20to%20parse.%0A%0A%60%60%60suggestion%0Adef%20_make_failure_result%28error_msg%3A%20str%29%20-%3E%20dict%3A%0A%20%20%20%20return%20%7B%0A%20%20%20%20%20%20%20%20%22status%22%3A%20%22Fail%22%2C%0A%20%20%20%20%20%20%20%20%22resolved%22%3A%20False%2C%0A%20%20%20%20%20%20%20%20%22PASS_TO_PASS%22%3A%20%22N%2FA%22%2C%0A%20%20%20%20%20%20%20%20%22FAIL_TO_PASS%22%3A%20%22N%2FA%22%2C%0A%20%20%20%20%20%20%20%20%22error%22%3A%20error_msg%2C%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aswe_bench_pro_eval.py%3A305-311%0A%60_format_test_breakdown%60%20returns%20%60%220%2F0%20passed%22%60%20when%20%60expected%60%20is%20an%20empty%20set%20%28i.e.%2C%20the%20instance%20has%20no%20FAIL_TO_PASS%20or%20no%20PASS_TO_PASS%20tests%29.%20This%20is%20ambiguous%20%E2%80%94%20it%20looks%20identical%20to%20a%20case%20where%20all%20zero-of-zero%20tests%20ran%20and%20passed.%20A%20special%20case%20would%20make%20it%20unambiguous%20to%20readers%20and%20downstream%20parsers.%0A%0A%60%60%60suggestion%0Adef%20_format_test_breakdown%28expected%3A%20set%2C%20passed%3A%20set%29%20-%3E%20str%3A%0A%20%20%20%20if%20not%20expected%3A%0A%20%20%20%20%20%20%20%20return%20%22N%2FA%20%28no%20tests%29%22%0A%20%20%20%20actually_passed%20%3D%20expected%20%26%20passed%0A%20%20%20%20failed%20%3D%20expected%20-%20passed%0A%20%20%20%20line%20%3D%20f%22%7Blen%28actually_passed%29%7D%2F%7Blen%28expected%29%7D%20passed%22%0A%20%20%20%20if%20failed%3A%0A%20%20%20%20%20%20%20%20line%20%2B%3D%20f%22%20%28failed%3A%20%7B'%2C%20'.join%28sorted%28failed%29%29%7D%29%22%0A%20%20%20%20return%20line%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
swe_bench_pro_eval.py:295-302
Inconsistent `PASS_TO_PASS`/`FAIL_TO_PASS` value format between the two result constructors. `_make_failure_result` stores empty strings `""` for these fields, while `_build_detailed_result` always stores a formatted `"N/M passed (failed: ...)"` string. The module-level schema comment documents both fields as `"N/M passed (failed: a, b, c)"` without noting the empty-string exception, so any consumer that tries to parse the count (`result["FAIL_TO_PASS"].split("/")[0]`, etc.) will crash on infra-failure entries. Setting these to `"N/A"` for infra failures would make the format uniform and safe to parse.

```suggestion
def _make_failure_result(error_msg: str) -> dict:
    return {
        "status": "Fail",
        "resolved": False,
        "PASS_TO_PASS": "N/A",
        "FAIL_TO_PASS": "N/A",
        "error": error_msg,
    }
```

### Issue 2 of 2
swe_bench_pro_eval.py:305-311
`_format_test_breakdown` returns `"0/0 passed"` when `expected` is an empty set (i.e., the instance has no FAIL_TO_PASS or no PASS_TO_PASS tests). This is ambiguous — it looks identical to a case where all zero-of-zero tests ran and passed. A special case would make it unambiguous to readers and downstream parsers.

```suggestion
def _format_test_breakdown(expected: set, passed: set) -> str:
    if not expected:
        return "N/A (no tests)"
    actually_passed = expected & passed
    failed = expected - passed
    line = f"{len(actually_passed)}/{len(expected)} passed"
    if failed:
        line += f" (failed: {', '.join(sorted(failed))})"
    return line
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add detailed eval\_results schema (status..."](https://github.com/scaleapi/swe-bench_pro-os/commit/aaddd977f0e761aa00ec9e27346b89bd994698c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35281446)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->