### PR TITLE
Fix: raise docker client timeout so slow evals aren't silently scored unresolved

### DIFF
--- a/swe_bench_pro_eval.py
+++ b/swe_bench_pro_eval.py
@@ -53,6 +53,9 @@ from tqdm import tqdm
 
 from helper_code.image_uri import get_dockerhub_image_uri
 
+# Docker's default 60s client read timeout is too short for long-running test suites.
+DOCKER_CLIENT_TIMEOUT = int(os.environ.get("DOCKER_CLIENT_TIMEOUT", "3600"))
+
 # Credit: prabhuteja12
 def load_base_docker(iid):
     with open(f"dockerfiles/base_dockerfile/{iid}/Dockerfile") as fp:
@@ -378,7 +381,7 @@ def eval_with_docker(patch, sample, output_dir, dockerhub_username, scripts_dir,
         dockerhub_image_uri = get_dockerhub_image_uri(uid, dockerhub_username, sample.get("repo", ""))
         print(f"Using Docker Hub image: {dockerhub_image_uri}")
 
-        client = docker.from_env()
+        client = docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)
         try:
             if docker_platform:
                 client.images.pull(dockerhub_image_uri, platform=docker_platform)


### PR DESCRIPTION
docker.from_env() uses the SDK default 60s read timeout. On the --use_local_docker path, container.wait() then raises ReadTimeout for any test suite whose exec exceeds 60s (routine for Go/JS repos), so no output.json is written and the instance is silently scored unresolved.

Add DOCKER_CLIENT_TIMEOUT (default 3600s, overridable via env) and use it for the docker client. Modal path unaffected.

Fixes the false-negatives observed in #54, #22, #23.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes silent scoring failures on `--use_local_docker` runs where test suites (especially Go/JS repos) take longer than the Docker SDK's default 60-second read timeout, causing `container.wait()` to raise `ReadTimeout` before `output.json` is written. The fix introduces a module-level `DOCKER_CLIENT_TIMEOUT` constant (default 3600 s, overridable via env) and passes it to `docker.from_env()`.

- Adds `DOCKER_CLIENT_TIMEOUT = int(os.environ.get("DOCKER_CLIENT_TIMEOUT", "3600"))` as a named, overridable constant replacing the implicit SDK default.
- Passes the timeout to `docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)` so all Docker API calls on the local path — including `container.wait()` — use the extended timeout.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the fix correctly targets the root cause of silent unresolved scoring on long-running test suites.

The change is minimal and well-scoped. The only subtlety is that the new timeout applies to every Docker API call on the client — including image pulls — not just container.wait(). A stalled registry pull would now block a worker for up to an hour instead of 60 s, but this is unlikely in practice and does not affect correctness.

swe_bench_pro_eval.py — specifically the images.pull() call that now shares the 3600 s timeout with container.wait()
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| swe_bench_pro_eval.py | Introduces DOCKER_CLIENT_TIMEOUT constant (default 3600s, env-overridable) and passes it to docker.from_env(); correctly extends the read timeout for container.wait() and all other Docker API calls on the local path. The broad timeout also applies to images.pull(), which is a minor tradeoff. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Eval as eval_with_docker()
    participant SDK as docker.from_env(timeout=3600)
    participant Daemon as Docker Daemon
    participant Container as Container

    Eval->>SDK: "docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)"
    SDK-->>Eval: client

    Eval->>Daemon: client.images.pull(image_uri)
    Daemon-->>Eval: image pulled

    Eval->>Daemon: "client.containers.run(..., detach=True, remove=True)"
    Daemon-->>Eval: container handle

    Eval->>Daemon: container.wait()
    note over Eval,Daemon: Blocks up to 3600s (was 60s)
    Daemon->>Container: runs entryscript.sh
    Container-->>Daemon: exit code
    Daemon-->>Eval: StatusCode

    Eval->>Eval: collect_outputs_local() → output.json written
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Eval as eval_with_docker()
    participant SDK as docker.from_env(timeout=3600)
    participant Daemon as Docker Daemon
    participant Container as Container

    Eval->>SDK: "docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)"
    SDK-->>Eval: client

    Eval->>Daemon: client.images.pull(image_uri)
    Daemon-->>Eval: image pulled

    Eval->>Daemon: "client.containers.run(..., detach=True, remove=True)"
    Daemon-->>Eval: container handle

    Eval->>Daemon: container.wait()
    note over Eval,Daemon: Blocks up to 3600s (was 60s)
    Daemon->>Container: runs entryscript.sh
    Container-->>Daemon: exit code
    Daemon-->>Eval: StatusCode

    Eval->>Eval: collect_outputs_local() → output.json written
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `swe_bench_pro_eval.py`, line 384-389 ([link](https://github.com/scaleapi/swe-bench_pro-os/blob/00edb8db7715e0376079362884ee2daeee18f712/swe_bench_pro_eval.py#L384-L389)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `timeout` passed to `docker.from_env()` is a socket-level read timeout that applies to **all** API calls on this client, including `images.pull()`. A hung or very slow registry pull will now block for up to 3600 s before raising an error, which may leave a worker silently stalled. Consider using a shorter, separate timeout for the pull call via `docker.APIClient` or by wrapping `images.pull()` with a `threading.Timer`, or at minimum document this tradeoff in the comment.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: swe_bench_pro_eval.py
   Line: 384-389

   Comment:
   The `timeout` passed to `docker.from_env()` is a socket-level read timeout that applies to **all** API calls on this client, including `images.pull()`. A hung or very slow registry pull will now block for up to 3600 s before raising an error, which may leave a worker silently stalled. Consider using a shorter, separate timeout for the pull call via `docker.APIClient` or by wrapping `images.pull()` with a `threading.Timer`, or at minimum document this tradeoff in the comment.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20swe_bench_pro_eval.py%0ALine%3A%20384-389%0A%0AComment%3A%0AThe%20%60timeout%60%20passed%20to%20%60docker.from_env%28%29%60%20is%20a%20socket-level%20read%20timeout%20that%20applies%20to%20**all**%20API%20calls%20on%20this%20client%2C%20including%20%60images.pull%28%29%60.%20A%20hung%20or%20very%20slow%20registry%20pull%20will%20now%20block%20for%20up%20to%203600%20s%20before%20raising%20an%20error%2C%20which%20may%20leave%20a%20worker%20silently%20stalled.%20Consider%20using%20a%20shorter%2C%20separate%20timeout%20for%20the%20pull%20call%20via%20%60docker.APIClient%60%20or%20by%20wrapping%20%60images.pull%28%29%60%20with%20a%20%60threading.Timer%60%2C%20or%20at%20minimum%20document%20this%20tradeoff%20in%20the%20comment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20timeout%20applies%20to%20all%20SDK%20calls%20on%20this%20client%20%28pull%20%2B%20wait%29.%0A%20%20%20%20%20%20%20%20%23%20Pull%20timeouts%20are%20less%20likely%20to%20be%20long%2C%20but%20if%20a%20registry%20stalls%2C%0A%20%20%20%20%20%20%20%20%23%20the%20worker%20will%20block%20for%20DOCKER_CLIENT_TIMEOUT%20seconds.%0A%20%20%20%20%20%20%20%20client%20%3D%20docker.from_env%28timeout%3DDOCKER_CLIENT_TIMEOUT%29%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20docker_platform%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%2C%20platform%3Ddocker_platform%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20swe_bench_pro_eval.py%0ALine%3A%20384-389%0A%0AComment%3A%0AThe%20%60timeout%60%20passed%20to%20%60docker.from_env%28%29%60%20is%20a%20socket-level%20read%20timeout%20that%20applies%20to%20**all**%20API%20calls%20on%20this%20client%2C%20including%20%60images.pull%28%29%60.%20A%20hung%20or%20very%20slow%20registry%20pull%20will%20now%20block%20for%20up%20to%203600%20s%20before%20raising%20an%20error%2C%20which%20may%20leave%20a%20worker%20silently%20stalled.%20Consider%20using%20a%20shorter%2C%20separate%20timeout%20for%20the%20pull%20call%20via%20%60docker.APIClient%60%20or%20by%20wrapping%20%60images.pull%28%29%60%20with%20a%20%60threading.Timer%60%2C%20or%20at%20minimum%20document%20this%20tradeoff%20in%20the%20comment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20timeout%20applies%20to%20all%20SDK%20calls%20on%20this%20client%20%28pull%20%2B%20wait%29.%0A%20%20%20%20%20%20%20%20%23%20Pull%20timeouts%20are%20less%20likely%20to%20be%20long%2C%20but%20if%20a%20registry%20stalls%2C%0A%20%20%20%20%20%20%20%20%23%20the%20worker%20will%20block%20for%20DOCKER_CLIENT_TIMEOUT%20seconds.%0A%20%20%20%20%20%20%20%20client%20%3D%20docker.from_env%28timeout%3DDOCKER_CLIENT_TIMEOUT%29%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20docker_platform%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%2C%20platform%3Ddocker_platform%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fswe-bench_pro-os&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fswe-bench_pro-os%22%20on%20the%20existing%20branch%20%22fix%2Fdocker-client-read-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdocker-client-read-timeout%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20swe_bench_pro_eval.py%0ALine%3A%20384-389%0A%0AComment%3A%0AThe%20%60timeout%60%20passed%20to%20%60docker.from_env%28%29%60%20is%20a%20socket-level%20read%20timeout%20that%20applies%20to%20**all**%20API%20calls%20on%20this%20client%2C%20including%20%60images.pull%28%29%60.%20A%20hung%20or%20very%20slow%20registry%20pull%20will%20now%20block%20for%20up%20to%203600%20s%20before%20raising%20an%20error%2C%20which%20may%20leave%20a%20worker%20silently%20stalled.%20Consider%20using%20a%20shorter%2C%20separate%20timeout%20for%20the%20pull%20call%20via%20%60docker.APIClient%60%20or%20by%20wrapping%20%60images.pull%28%29%60%20with%20a%20%60threading.Timer%60%2C%20or%20at%20minimum%20document%20this%20tradeoff%20in%20the%20comment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20timeout%20applies%20to%20all%20SDK%20calls%20on%20this%20client%20%28pull%20%2B%20wait%29.%0A%20%20%20%20%20%20%20%20%23%20Pull%20timeouts%20are%20less%20likely%20to%20be%20long%2C%20but%20if%20a%20registry%20stalls%2C%0A%20%20%20%20%20%20%20%20%23%20the%20worker%20will%20block%20for%20DOCKER_CLIENT_TIMEOUT%20seconds.%0A%20%20%20%20%20%20%20%20client%20%3D%20docker.from_env%28timeout%3DDOCKER_CLIENT_TIMEOUT%29%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20docker_platform%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%2C%20platform%3Ddocker_platform%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=scaleapi%2Fswe-bench_pro-os&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aswe_bench_pro_eval.py%3A384-389%0AThe%20%60timeout%60%20passed%20to%20%60docker.from_env%28%29%60%20is%20a%20socket-level%20read%20timeout%20that%20applies%20to%20**all**%20API%20calls%20on%20this%20client%2C%20including%20%60images.pull%28%29%60.%20A%20hung%20or%20very%20slow%20registry%20pull%20will%20now%20block%20for%20up%20to%203600%20s%20before%20raising%20an%20error%2C%20which%20may%20leave%20a%20worker%20silently%20stalled.%20Consider%20using%20a%20shorter%2C%20separate%20timeout%20for%20the%20pull%20call%20via%20%60docker.APIClient%60%20or%20by%20wrapping%20%60images.pull%28%29%60%20with%20a%20%60threading.Timer%60%2C%20or%20at%20minimum%20document%20this%20tradeoff%20in%20the%20comment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20timeout%20applies%20to%20all%20SDK%20calls%20on%20this%20client%20%28pull%20%2B%20wait%29.%0A%20%20%20%20%20%20%20%20%23%20Pull%20timeouts%20are%20less%20likely%20to%20be%20long%2C%20but%20if%20a%20registry%20stalls%2C%0A%20%20%20%20%20%20%20%20%23%20the%20worker%20will%20block%20for%20DOCKER_CLIENT_TIMEOUT%20seconds.%0A%20%20%20%20%20%20%20%20client%20%3D%20docker.from_env%28timeout%3DDOCKER_CLIENT_TIMEOUT%29%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20docker_platform%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%2C%20platform%3Ddocker_platform%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%29%0A%60%60%60%0A%0A&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aswe_bench_pro_eval.py%3A384-389%0AThe%20%60timeout%60%20passed%20to%20%60docker.from_env%28%29%60%20is%20a%20socket-level%20read%20timeout%20that%20applies%20to%20**all**%20API%20calls%20on%20this%20client%2C%20including%20%60images.pull%28%29%60.%20A%20hung%20or%20very%20slow%20registry%20pull%20will%20now%20block%20for%20up%20to%203600%20s%20before%20raising%20an%20error%2C%20which%20may%20leave%20a%20worker%20silently%20stalled.%20Consider%20using%20a%20shorter%2C%20separate%20timeout%20for%20the%20pull%20call%20via%20%60docker.APIClient%60%20or%20by%20wrapping%20%60images.pull%28%29%60%20with%20a%20%60threading.Timer%60%2C%20or%20at%20minimum%20document%20this%20tradeoff%20in%20the%20comment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20timeout%20applies%20to%20all%20SDK%20calls%20on%20this%20client%20%28pull%20%2B%20wait%29.%0A%20%20%20%20%20%20%20%20%23%20Pull%20timeouts%20are%20less%20likely%20to%20be%20long%2C%20but%20if%20a%20registry%20stalls%2C%0A%20%20%20%20%20%20%20%20%23%20the%20worker%20will%20block%20for%20DOCKER_CLIENT_TIMEOUT%20seconds.%0A%20%20%20%20%20%20%20%20client%20%3D%20docker.from_env%28timeout%3DDOCKER_CLIENT_TIMEOUT%29%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20docker_platform%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%2C%20platform%3Ddocker_platform%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fswe-bench_pro-os&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22scaleapi%2Fswe-bench_pro-os%22%20on%20the%20existing%20branch%20%22fix%2Fdocker-client-read-timeout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdocker-client-read-timeout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aswe_bench_pro_eval.py%3A384-389%0AThe%20%60timeout%60%20passed%20to%20%60docker.from_env%28%29%60%20is%20a%20socket-level%20read%20timeout%20that%20applies%20to%20**all**%20API%20calls%20on%20this%20client%2C%20including%20%60images.pull%28%29%60.%20A%20hung%20or%20very%20slow%20registry%20pull%20will%20now%20block%20for%20up%20to%203600%20s%20before%20raising%20an%20error%2C%20which%20may%20leave%20a%20worker%20silently%20stalled.%20Consider%20using%20a%20shorter%2C%20separate%20timeout%20for%20the%20pull%20call%20via%20%60docker.APIClient%60%20or%20by%20wrapping%20%60images.pull%28%29%60%20with%20a%20%60threading.Timer%60%2C%20or%20at%20minimum%20document%20this%20tradeoff%20in%20the%20comment.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20timeout%20applies%20to%20all%20SDK%20calls%20on%20this%20client%20%28pull%20%2B%20wait%29.%0A%20%20%20%20%20%20%20%20%23%20Pull%20timeouts%20are%20less%20likely%20to%20be%20long%2C%20but%20if%20a%20registry%20stalls%2C%0A%20%20%20%20%20%20%20%20%23%20the%20worker%20will%20block%20for%20DOCKER_CLIENT_TIMEOUT%20seconds.%0A%20%20%20%20%20%20%20%20client%20%3D%20docker.from_env%28timeout%3DDOCKER_CLIENT_TIMEOUT%29%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20docker_platform%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%2C%20platform%3Ddocker_platform%29%0A%20%20%20%20%20%20%20%20%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20client.images.pull%28dockerhub_image_uri%29%0A%60%60%60%0A%0A&repo=scaleapi%2Fswe-bench_pro-os&pr=111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
swe_bench_pro_eval.py:384-389
The `timeout` passed to `docker.from_env()` is a socket-level read timeout that applies to **all** API calls on this client, including `images.pull()`. A hung or very slow registry pull will now block for up to 3600 s before raising an error, which may leave a worker silently stalled. Consider using a shorter, separate timeout for the pull call via `docker.APIClient` or by wrapping `images.pull()` with a `threading.Timer`, or at minimum document this tradeoff in the comment.

```suggestion
        # timeout applies to all SDK calls on this client (pull + wait).
        # Pull timeouts are less likely to be long, but if a registry stalls,
        # the worker will block for DOCKER_CLIENT_TIMEOUT seconds.
        client = docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)
        try:
            if docker_platform:
                client.images.pull(dockerhub_image_uri, platform=docker_platform)
            else:
                client.images.pull(dockerhub_image_uri)
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix: raise docker client timeout so slow..."](https://github.com/scaleapi/swe-bench_pro-os/commit/00edb8db7715e0376079362884ee2daeee18f712) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41856208)</sub>

<!-- /greptile_comment -->